### PR TITLE
Removed deprecated attribute from all Compose implementations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-variables: &variables
   ENV_STAGE: local
 

--- a/docker/modules/autoheal.yml
+++ b/docker/modules/autoheal.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   autoheal:
     restart: always

--- a/docker/modules/gitlab.runner.yml
+++ b/docker/modules/gitlab.runner.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   runner:
     container_name: gitlab-runner

--- a/docker/modules/jaeger.yml
+++ b/docker/modules/jaeger.yml
@@ -3,8 +3,6 @@
 # which need optimizations, fixes or deeper debugging
 # For using GUI: http://localhost:16686
 
-version: '3.7'
-
 services:
   jaeger:
     image: jaegertracing/all-in-one

--- a/docker/modules/mailhog.yml
+++ b/docker/modules/mailhog.yml
@@ -1,7 +1,5 @@
 # SMTP Server for mail testing
 
-version: '3.7'
-
 services:
   mailhog:
     image: mailhog/mailhog

--- a/docker/modules/pg_backup.yml
+++ b/docker/modules/pg_backup.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   pgbackups:
     image: prodrigestivill/postgres-backup-local

--- a/docker/modules/rabbitmq.yml
+++ b/docker/modules/rabbitmq.yml
@@ -1,7 +1,5 @@
 # Message Broker RabbitMQ for Celery queues
 
-version: '3.7'
-
 services:
   rabbitmq:
     image: rabbitmq:3-management

--- a/docs/source/environ/project_env.rst
+++ b/docs/source/environ/project_env.rst
@@ -1,7 +1,5 @@
 .. code-block:: yaml
 
-   version: "3.7"
-
    x-variables: &variables
      ENV_STAGE: dev
      USE_HTTPS: 0

--- a/prod.certbot.yml
+++ b/prod.certbot.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   nginx:
     image: staticfloat/nginx-certbot

--- a/prod.yml
+++ b/prod.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-variables: &variables
   ENV_STAGE: dev
   USE_HTTPS: 0


### PR DESCRIPTION
Here is a link to [documentation](https://docs.docker.com/compose/compose-file/#compose-file) where the `version` attribute in all Compose implementations marked as deprecated.